### PR TITLE
Add Express API for PostgreSQL queries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+PORT=3000
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=seu_banco
+DB_USER=seu_usuario
+DB_PASSWORD=sua_senha
+# Defina para 'true' se precisar habilitar SSL (por exemplo, ao conectar em serviços gerenciados)
+DB_SSL=false
+# Valores opcionais para ajustar o pool de conexões
+DB_POOL_MAX=10
+DB_POOL_IDLE=30000

--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# altera_numero_de_telefone
+# API de consultas PostgreSQL
+
+Esta aplicação expõe três endpoints HTTP em Node.js/Express que consultam um banco de dados PostgreSQL e retornam os registros das tabelas `history`, `conversation` e `rental`.
+
+## Pré-requisitos
+
+- Node.js 18 ou superior
+- Banco de dados PostgreSQL acessível com as tabelas necessárias
+
+## Configuração
+
+1. Copie o arquivo `.env.example` para `.env` e ajuste as variáveis de conexão com o banco:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Instale as dependências do projeto:
+
+   ```bash
+   npm install
+   ```
+
+## Execução
+
+Inicie o servidor com:
+
+```bash
+npm start
+```
+
+O serviço ficará disponível em `http://localhost:3000` (ou na porta definida pela variável `PORT`).
+
+### Endpoints
+
+- `GET /history` – retorna todos os registros da tabela `history`.
+- `GET /conversation` – retorna todos os registros da tabela `conversation`.
+- `GET /rental` – retorna todos os registros da tabela `rental`.
+
+As respostas são fornecidas em formato JSON. Em caso de erro na consulta ao banco de dados, o serviço retorna o status HTTP `500` com uma mensagem de erro.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "altera_numero_de_telefone",
+  "version": "1.0.0",
+  "description": "API em Node.js com Express para consultar tabelas history, conversation e rental em um banco PostgreSQL.",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "dev": "node --watch src/server.js"
+  },
+  "keywords": [
+    "express",
+    "postgresql",
+    "api"
+  ],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "pg": "^8.11.3"
+  }
+}

--- a/src/db.js
+++ b/src/db.js
@@ -1,0 +1,18 @@
+const { Pool } = require('pg');
+
+const pool = new Pool({
+  host: process.env.DB_HOST,
+  port: process.env.DB_PORT ? Number(process.env.DB_PORT) : undefined,
+  database: process.env.DB_NAME,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  ssl: process.env.DB_SSL === 'true' ? { rejectUnauthorized: false } : undefined,
+  max: process.env.DB_POOL_MAX ? Number(process.env.DB_POOL_MAX) : undefined,
+  idleTimeoutMillis: process.env.DB_POOL_IDLE ? Number(process.env.DB_POOL_IDLE) : undefined,
+});
+
+const query = (text, params) => pool.query(text, params);
+
+module.exports = {
+  query,
+};

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,43 @@
+require('dotenv').config();
+const express = require('express');
+
+const { getHistory } = require('./services/historyService');
+const { getConversation } = require('./services/conversationService');
+const { getRental } = require('./services/rentalService');
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.get('/history', async (req, res) => {
+  try {
+    const history = await getHistory();
+    res.json(history);
+  } catch (error) {
+    console.error('Erro ao buscar histórico', error);
+    res.status(500).json({ message: 'Erro ao buscar registros de history.' });
+  }
+});
+
+app.get('/conversation', async (req, res) => {
+  try {
+    const conversation = await getConversation();
+    res.json(conversation);
+  } catch (error) {
+    console.error('Erro ao buscar conversation', error);
+    res.status(500).json({ message: 'Erro ao buscar registros de conversation.' });
+  }
+});
+
+app.get('/rental', async (req, res) => {
+  try {
+    const rental = await getRental();
+    res.json(rental);
+  } catch (error) {
+    console.error('Erro ao buscar rental', error);
+    res.status(500).json({ message: 'Erro ao buscar registros de rental.' });
+  }
+});
+
+app.listen(port, () => {
+  console.log(`Servidor iniciado na porta ${port}`);
+});

--- a/src/services/conversationService.js
+++ b/src/services/conversationService.js
@@ -1,0 +1,10 @@
+const db = require('../db');
+
+const getConversation = async () => {
+  const result = await db.query('SELECT * FROM conversation');
+  return result.rows;
+};
+
+module.exports = {
+  getConversation,
+};

--- a/src/services/historyService.js
+++ b/src/services/historyService.js
@@ -1,0 +1,10 @@
+const db = require('../db');
+
+const getHistory = async () => {
+  const result = await db.query('SELECT * FROM history');
+  return result.rows;
+};
+
+module.exports = {
+  getHistory,
+};

--- a/src/services/rentalService.js
+++ b/src/services/rentalService.js
@@ -1,0 +1,10 @@
+const db = require('../db');
+
+const getRental = async () => {
+  const result = await db.query('SELECT * FROM rental');
+  return result.rows;
+};
+
+module.exports = {
+  getRental,
+};


### PR DESCRIPTION
## Summary
- add an Express server with `/history`, `/conversation` e `/rental` endpoints que consultam tabelas PostgreSQL
- centralize a configuração de acesso ao banco em um serviço com variáveis de ambiente e arquivo `.env.example`
- documentar no README como configurar variáveis e executar a API

## Testing
- not run (npm dependencies unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d8686501a88321890dc6c6f04b832b